### PR TITLE
Fixes Donut altmetric size

### DIFF
--- a/styles/badges.css
+++ b/styles/badges.css
@@ -1,11 +1,9 @@
-.__dimensions_badge_embed__, 
-.altmetric-embed,
-.plx-print {
-  width: 5rem;
-  height: 5rem;
-  display: flex;
-  align-items: center;
-  justify-content: left;
+.obj_article_details .sub_item {
+  margin: 1.25rem 0;
+}
+
+.altmetric-embed > a > img {
+  width: 4rem;
 }
 
 .PlumX-Popup .ppp-container.ppp-large > a,
@@ -16,5 +14,3 @@
   margin-top: -1rem;
   margin-left: -1.75rem;
 }
-
-


### PR DESCRIPTION
In the [previous pull request](https://github.com/sedici/badges/pull/2) made to adapt the plugin for OPS, corrections to the alignment and size of the elements were added. However, in `Altmetric Donut` the correction was made incorrectly, causing it to remain with an irregular size when it is active (with mentions).

![donutIncorretAlign](https://user-images.githubusercontent.com/90649263/193359159-7fa853ee-591d-483a-bc07-fb925be3debb.png)

In this pull request, we added the fix for this issue.